### PR TITLE
Fix for tf-apply job with reviewers ...

### DIFF
--- a/.github/workflows/tfc-deploy-enterprise.yaml
+++ b/.github/workflows/tfc-deploy-enterprise.yaml
@@ -144,13 +144,17 @@ jobs:
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment_name }}
     container: ghcr.io/guidionops/terraform-cloud-deployer:0.1.0
-    if: always()
+    if: ${{ !cancelled() }}
     steps:
-        # The first step is a bit of a hack. It allows us to have the
-        # conditional plan above, whilst still using 'needs' on this job even if
-        # that conditional job doesn't run
+        # This first step allows us to specify the plan job above in "needs",
+        # even if it doesn't run. Done by:
+        #   - Setting "if" to "!cancelled()", so that this job always runs (essentially
+        #     overriding the "needs"), unless the workflow is cancelled
+        #   - Failing this job if the result of the plan job is "failure" or "cancelled"
+        # This means that this job will always run (even if the plan job doesn't)
+        # but is still affected by a bad result from the plan job when that job does run
       - name: Fail if tf-plan failed
-        if: ${{ needs.tf-plan.result == 'failure' }}
+        if: ${{ contains(fromJSON('["failure"], ["cancelled"]'), needs.tf-plan.result) }}
         run: exit 1
       - name: Get the build artifacts and Terraform files
         uses: actions/download-artifact@v4

--- a/.github/workflows/tfc-deploy.yaml
+++ b/.github/workflows/tfc-deploy.yaml
@@ -75,7 +75,6 @@ jobs:
     steps:
       - name: cancel
         run: tfcd -t ${{ secrets.tfc_api_token }} -w ${{ inputs.tfc_workspace || vars.tfc_workspace }} run cancel --auto-approve current
-
   tf-init:
     needs: cancel
     runs-on: ubuntu-latest
@@ -105,7 +104,6 @@ jobs:
             **/*.terraform
             **/*.terraform.lock.hcl
           retention-days: ${{ inputs.retention-days || vars.retention-days }}
-
   tf-plan:
     # We can't use if at this level because of this bug in Github Actions:
     # https://github.com/orgs/community/discussions/113313
@@ -142,7 +140,6 @@ jobs:
         with:
           secret: ${{ steps.generate_approver_token.outputs.token || github.TOKEN }}
           approvers: ${{ inputs.tfc_approvers || vars.tfc_approvers }}
-
   tf-apply:
     needs: tf-plan
     runs-on: ubuntu-latest

--- a/.github/workflows/tfc-test-application-module-enterprise.yaml
+++ b/.github/workflows/tfc-test-application-module-enterprise.yaml
@@ -97,7 +97,6 @@ jobs:
         run: |
           terraform test
 
-
   tf-plan:
     needs: tf-init
     runs-on: ubuntu-latest

--- a/.github/workflows/tfc-test-helper-module-enterprise.yaml
+++ b/.github/workflows/tfc-test-helper-module-enterprise.yaml
@@ -4,7 +4,6 @@ on:
 jobs:
   test-list:
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v4
       - id: set-matrix
@@ -12,16 +11,12 @@ jobs:
         run: echo "matrix=$(ls | jq -R -s -c 'split("\n")[:-1]')" >> "$GITHUB_OUTPUT"
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
-
-
   tests:
     runs-on: ubuntu-latest
     needs: [ test-list ]
-
     strategy:
-      matrix: 
+      matrix:
         folders: ${{ fromJson(needs.test-list.outputs.matrix) }}
-
     steps:
       - uses: actions/checkout@v4
       - name: Start LocalStack

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+[![forthebadge](https://forthebadge.com/images/badges/built-with-resentment.svg)](https://forthebadge.com)
+[![forthebadge](https://forthebadge.com/images/badges/compatibility-betamax.svg)](https://forthebadge.com)
+[![forthebadge](https://forthebadge.com/images/badges/powered-by-overtime.svg)](https://forthebadge.com)
+[![forthebadge](https://forthebadge.com/images/badges/contains-tasty-spaghetti-code.svg)](https://forthebadge.com)
+
 N.B. Terrappy consists of many interdependent modules, and Guidion is still in the process of open sourcing them. This notice will be removed once the minimum dependency requirements are met, until then the ones that _are_ already available will not be of much use by themselves.
 
 ---


### PR DESCRIPTION
If the environment accessed needed reviewers but the workflow was cancelled, then the tf-apply job would hang until it timed out. Changing it's condition from `always` to `!cancelled` fixes this