### PR TITLE
New workflow for TFC-less applies

### DIFF
--- a/.github/workflows/tf-module-pr-planner.yaml
+++ b/.github/workflows/tf-module-pr-planner.yaml
@@ -61,6 +61,8 @@ jobs:
     env:
       AWS_ACCESS_KEY_ID: ${{ vars.MODULE_TESTER_AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.MODULE_TESTER_AWS_SECRET_ACCESS_KEY }}
+      TF_VAR_CHECKLY_ACCOUNT_ID: ${{ vars.TF_VAR_CHECKLY_ACCOUNT_ID }}
+      TF_VAR_CHECKLY_API_KEY: ${{ secrets.TF_VAR_CHECKLY_API_KEY }}
     defaults:
       run:
         working-directory: ${{ matrix.tf_examples_dirs }}

--- a/.github/workflows/tf-module-pr-planner.yaml
+++ b/.github/workflows/tf-module-pr-planner.yaml
@@ -1,5 +1,18 @@
 name: Test PRs by running Terraform plans
 
+# Pass secrets and variables to be set in the environment with inputs.environment_variables
+# and secrets.environment_secrets. Both must have items set on newlines, like so:
+#
+# with:
+#   environment_variables: |
+#     EXAMPLE_VARIABLE=${{ vars.example_variable }}
+# secrets:
+#   environment_secrets: |
+#     EXAMPLE_SECRET=${{ secrets.example_secret }}
+#
+# Do not pass secrets down as plaintext values, but rather references to Github
+# secrets, as in the example above. Variables can be passed as plain text
+
 # N.B. When relying on this workflow as a required check, you must use the
 # exact name: '[YOUR JOB NAME] / completed'
 
@@ -68,8 +81,6 @@ jobs:
       fail-fast: false
     environment: ${{ inputs.environment }}
     env:
-      AWS_ACCESS_KEY_ID: ${{ vars.MODULE_TESTER_AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.MODULE_TESTER_AWS_SECRET_ACCESS_KEY }}
       ENVIRONMENT_VARIABLES: ${{ inputs.environment_variables }}
       ENVIRONMENT_SECRETS: ${{ secrets.environment_secrets }}
     defaults:

--- a/.github/workflows/tf-module-pr-planner.yaml
+++ b/.github/workflows/tf-module-pr-planner.yaml
@@ -77,12 +77,12 @@ jobs:
         working-directory: ${{ matrix.tf_examples_dirs }}
     container: ghcr.io/guidionops/terraform-cloud-deployer:0.1.1
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
       - name: Load variables from caller
         run: |
           echo "$ENVIRONMENT_VARIABLES" >> $GITHUB_ENV
           echo "$ENVIRONMENT_SECRETS" >> $GITHUB_ENV
-      - name: Checkout repository
-        uses: actions/checkout@v4
       - name: See env values
         run: printenv
       - name: Terraform init

--- a/.github/workflows/tf-module-pr-planner.yaml
+++ b/.github/workflows/tf-module-pr-planner.yaml
@@ -71,6 +71,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+      - name: See env values
+        run: printenv
       - name: Terraform init
         run: terraform init
       - name: Run terraform plan with auto-approval

--- a/.github/workflows/tf-module-pr-planner.yaml
+++ b/.github/workflows/tf-module-pr-planner.yaml
@@ -34,6 +34,7 @@ jobs:
       contents: read
 
   terraform-file-changes:
+    needs: test-workflow
     runs-on: ubuntu-latest
     outputs:
       result: ${{ steps.terraform-file-changes.outputs.terraform }}

--- a/.github/workflows/tf-module-pr-planner.yaml
+++ b/.github/workflows/tf-module-pr-planner.yaml
@@ -62,8 +62,8 @@ jobs:
     env:
       AWS_ACCESS_KEY_ID: ${{ vars.MODULE_TESTER_AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.MODULE_TESTER_AWS_SECRET_ACCESS_KEY }}
-      TF_VAR_CHECKLY_ACCOUNT_ID: ${{ vars.TF_VAR_CHECKLY_ACCOUNT_ID }}
-      TF_VAR_CHECKLY_API_KEY: ${{ secrets.TF_VAR_CHECKLY_API_KEY }}
+      TF_VAR_checkly_account_id: ${{ vars.TF_VAR_CHECKLY_ACCOUNT_ID }}
+      TF_VAR_checkly_api_key: ${{ secrets.TF_VAR_CHECKLY_API_KEY }}
     defaults:
       run:
         working-directory: ${{ matrix.tf_examples_dirs }}
@@ -71,6 +71,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+      - name: See env values
+        run: printenv
       - name: Terraform init
         run: terraform init
       - name: Run terraform plan with auto-approval

--- a/.github/workflows/tf-module-pr-planner.yaml
+++ b/.github/workflows/tf-module-pr-planner.yaml
@@ -17,10 +17,18 @@ on:
         type: boolean
         default: true
       environment:
-        description: Github environment to attach with extra variables
+        description: Github environment to attach
         required: false
         type: string
         default: ""
+      environment_variables:
+        description: Variables to set in the environment (KEY=value format)
+        required: false
+        type: string
+    secrets:
+      environment_secrets:
+        description: Secrets to set in the environment (KEY=value format)
+        required: false
     outputs:
       terraform-file-changes-result:
         description: "Output from terraform-file-changes GH Actions"
@@ -62,13 +70,17 @@ jobs:
     env:
       AWS_ACCESS_KEY_ID: ${{ vars.MODULE_TESTER_AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.MODULE_TESTER_AWS_SECRET_ACCESS_KEY }}
-      # TF_VAR_checkly_account_id: ${{ vars.TF_VAR_CHECKLY_ACCOUNT_ID }}
-      # TF_VAR_checkly_api_key: ${{ secrets.TF_VAR_CHECKLY_API_KEY }}
+      ENVIRONMENT_VARIABLES: ${{ inputs.environment_variables }}
+      ENVIRONMENT_SECRETS: ${{ secrets.environment_secrets }}
     defaults:
       run:
         working-directory: ${{ matrix.tf_examples_dirs }}
     container: ghcr.io/guidionops/terraform-cloud-deployer:0.1.1
     steps:
+      - name: Load variables from caller
+        run: |
+          echo "$ENVIRONMENT_VARIABLES" >> $GITHUB_ENV
+          echo "$ENVIRONMENT_SECRETS" >> $GITHUB_ENV
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: See env values

--- a/.github/workflows/tf-module-pr-planner.yaml
+++ b/.github/workflows/tf-module-pr-planner.yaml
@@ -94,8 +94,6 @@ jobs:
         run: |
           echo "$ENVIRONMENT_VARIABLES" >> $GITHUB_ENV
           echo "$ENVIRONMENT_SECRETS" >> $GITHUB_ENV
-      - name: See env values
-        run: printenv
       - name: Terraform init
         run: terraform init
       - name: Run terraform plan with auto-approval

--- a/.github/workflows/tf-module-pr-planner.yaml
+++ b/.github/workflows/tf-module-pr-planner.yaml
@@ -92,8 +92,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Load variables from caller
         run: |
-          echo "$ENVIRONMENT_VARIABLES" >> $GITHUB_ENV
-          echo "$ENVIRONMENT_SECRETS" >> $GITHUB_ENV
+          echo "$ENVIRONMENT_VARIABLES" >> "$GITHUB_ENV"
+          echo "$ENVIRONMENT_SECRETS" >> "$GITHUB_ENV"
       - name: Terraform init
         run: terraform init
       - name: Run terraform plan with auto-approval

--- a/.github/workflows/tf-module-pr-planner.yaml
+++ b/.github/workflows/tf-module-pr-planner.yaml
@@ -1,0 +1,100 @@
+name: Test PRs by running Terraform plans
+
+# N.B. When relying on this workflow as a required check, you must use the
+# exact name: '[YOUR JOB NAME] / completed'
+
+on:
+  workflow_call:
+    inputs:
+      tf_examples_dirs:
+        description: List of directories to test (JSON array format)
+        required: false
+        type: string
+        default: '["examples/test_app"]'
+      destroy:
+        description: Destroy resources. Set to false to stop cleanup at the end of the apply job
+        required: false
+        type: boolean
+        default: true
+      environment:
+        description: Github environment to attach with extra variables
+        required: false
+        type: string
+        default: ""
+    outputs:
+      terraform-file-changes-result:
+        description: "Output from terraform-file-changes GH Actions"
+        value: ${{ jobs.terraform-file-changes.outputs.result }}
+
+jobs:
+  test-workflow:
+    uses: guidion-digital/release-workflows/.github/workflows/github-test-workflow.yaml@v2
+    permissions:
+      pull-requests: write
+      contents: read
+
+  terraform-file-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      result: ${{ steps.terraform-file-changes.outputs.terraform }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: terraform-file-changes
+        with:
+          filters: |
+            terraform:
+              - '**/*.tf'
+
+  tests-plan:
+    if: ${{ needs.terraform-file-changes.outputs.result == 'true' }}
+    needs: [terraform-file-changes]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    strategy:
+      matrix:
+        tf_examples_dirs: ${{ fromJson(inputs.tf_examples_dirs) }}
+      fail-fast: false
+    environment: ${{ inputs.environment }}
+    env:
+      AWS_ACCESS_KEY_ID: ${{ vars.MODULE_TESTER_AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.MODULE_TESTER_AWS_SECRET_ACCESS_KEY }}
+    defaults:
+      run:
+        working-directory: ${{ matrix.tf_examples_dirs }}
+    container: ghcr.io/guidionops/terraform-cloud-deployer:0.1.1
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Terraform init
+        run: terraform init
+      - name: Run terraform plan with auto-approval
+        run: terraform plan
+  # This is needed because matrix tests have dynamic workflow names based on the
+  # folder name. This is something we cannot make a required test from. Because
+  # skipped tests are marked as succesfull in GitHub required test, we test here
+  # if it was succesfully run and then mark it as such, if it's skipped or fails
+  # then it's marked as failed.
+  completed:
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    needs: [terraform-file-changes, tests-plan]
+    outputs:
+      tf-apply-result: ${{ needs.tests-plan.result }}
+    steps:
+      - name: No Terraform changes, or Terraform plan was successful
+        id: workflow-or-terraform-change
+        if: ${{ (needs.terraform-file-changes.outputs.result == 'false')  || (needs.tests-plan.result  == 'success') }}
+        run: exit 0
+      - name: Non-terraform change, or terraform plan failed
+        if: failure() || steps.workflow-or-terraform-change.outcome != 'success'
+        run: exit 1
+
+  release-dry-run:
+    if: ${{ always() && needs.tests-plan.result == 'success' }}
+    needs: tests-plan
+    uses: guidion-digital/release-workflows/.github/workflows/github-release-tag-dry-run.yaml@v2
+    with:
+      branch: ${{ github.ref_name }}

--- a/.github/workflows/tf-module-pr-planner.yaml
+++ b/.github/workflows/tf-module-pr-planner.yaml
@@ -62,8 +62,8 @@ jobs:
     env:
       AWS_ACCESS_KEY_ID: ${{ vars.MODULE_TESTER_AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.MODULE_TESTER_AWS_SECRET_ACCESS_KEY }}
-      TF_VAR_checkly_account_id: ${{ vars.TF_VAR_CHECKLY_ACCOUNT_ID }}
-      TF_VAR_checkly_api_key: ${{ secrets.TF_VAR_CHECKLY_API_KEY }}
+      # TF_VAR_checkly_account_id: ${{ vars.TF_VAR_CHECKLY_ACCOUNT_ID }}
+      # TF_VAR_checkly_api_key: ${{ secrets.TF_VAR_CHECKLY_API_KEY }}
     defaults:
       run:
         working-directory: ${{ matrix.tf_examples_dirs }}
@@ -71,8 +71,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - name: See env values
-        run: printenv
       - name: Terraform init
         run: terraform init
       - name: Run terraform plan with auto-approval

--- a/.github/workflows/tf-module-releaser.yaml
+++ b/.github/workflows/tf-module-releaser.yaml
@@ -1,5 +1,18 @@
 name: Release a version of a module if the terraform apply passes
 
+# Pass secrets and variables to be set in the environment with inputs.environment_variables
+# and secrets.environment_secrets. Both must have items set on newlines, like so:
+#
+# with:
+#   environment_variables: |
+#     EXAMPLE_VARIABLE=${{ vars.example_variable }}
+# secrets:
+#   environment_secrets: |
+#     EXAMPLE_SECRET=${{ secrets.example_secret }}
+#
+# Do not pass secrets down as plaintext values, but rather references to Github
+# secrets, as in the example above. Variables can be passed as plain text
+
 on:
   workflow_call:
     inputs:
@@ -18,6 +31,14 @@ on:
         required: false
         type: string
         default: ""
+      environment_variables:
+        description: Variables to set in the environment (KEY=value format)
+        required: false
+        type: string
+    secrets:
+      environment_secrets:
+        description: Secrets to set in the environment (KEY=value format)
+        required: false
     outputs:
       terraform-file-changes-result:
         description: "Output from terraform-file-changes GH Actions"
@@ -47,8 +68,8 @@ jobs:
       fail-fast: false
     environment: ${{ inputs.environment }}
     env:
-      AWS_ACCESS_KEY_ID: ${{ vars.MODULE_TESTER_AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.MODULE_TESTER_AWS_SECRET_ACCESS_KEY }}
+      ENVIRONMENT_VARIABLES: ${{ inputs.environment_variables }}
+      ENVIRONMENT_SECRETS: ${{ secrets.environment_secrets }}
     defaults:
       run:
         working-directory: ${{ matrix.tf_examples_dirs }}
@@ -56,6 +77,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+      - name: Load variables from caller
+        run: |
+          echo "$ENVIRONMENT_VARIABLES" >> $GITHUB_ENV
+          echo "$ENVIRONMENT_SECRETS" >> $GITHUB_ENV
       - name: Terraform init
         run: terraform init
       - name: Run terraform apply with auto-approval

--- a/.github/workflows/tf-module-releaser.yaml
+++ b/.github/workflows/tf-module-releaser.yaml
@@ -79,8 +79,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Load variables from caller
         run: |
-          echo "$ENVIRONMENT_VARIABLES" >> $GITHUB_ENV
-          echo "$ENVIRONMENT_SECRETS" >> $GITHUB_ENV
+          echo "$ENVIRONMENT_VARIABLES" >> "$GITHUB_ENV"
+          echo "$ENVIRONMENT_SECRETS" >> "$GITHUB_ENV"
       - name: Terraform init
         run: terraform init
       - name: Run terraform apply with auto-approval

--- a/.github/workflows/tf-module-releaser.yaml
+++ b/.github/workflows/tf-module-releaser.yaml
@@ -1,0 +1,102 @@
+name: Release a version of a module if the terraform apply passes
+
+on:
+  workflow_call:
+    inputs:
+      tf_examples_dirs:
+        description: List of directories to test (JSON array format)
+        required: false
+        type: string
+        default: '["examples/test_app"]'
+      destroy:
+        description: Destroy resources. Set to false to stop cleanup at the end of the apply job
+        required: false
+        type: boolean
+        default: true
+      environment:
+        description: Github environment to attach with extra variables
+        required: false
+        type: string
+        default: ""
+    outputs:
+      terraform-file-changes-result:
+        description: "Output from terraform-file-changes GH Actions"
+        value: ${{ jobs.terraform-file-changes.outputs.result }}
+
+jobs:
+  terraform-file-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      result: ${{ steps.terraform-file-changes.outputs.terraform }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: terraform-file-changes
+        with:
+          filters: |
+            terraform:
+              - '**/*.tf'
+
+  tf-apply:
+    if: ${{ needs.terraform-file-changes.outputs.result == 'true' }}
+    needs: [terraform-file-changes]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        tf_examples_dirs: ${{ fromJson(inputs.tf_examples_dirs) }}
+      fail-fast: false
+    environment: ${{ inputs.environment }}
+    env:
+      AWS_ACCESS_KEY_ID: ${{ vars.MODULE_TESTER_AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.MODULE_TESTER_AWS_SECRET_ACCESS_KEY }}
+    defaults:
+      run:
+        working-directory: ${{ matrix.tf_examples_dirs }}
+    container: ghcr.io/guidionops/terraform-cloud-deployer:0.1.1
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Terraform init
+        run: terraform init
+      - name: Run terraform apply with auto-approval
+        run: terraform apply -auto-approve
+      - name: Destroy all resources
+        if: always() && inputs.destroy
+        run: terraform destroy -auto-approve
+  # This is needed because matrix tests have dynamic workflow names based on the
+  # folder name. This is something we cannot make a required test from. Because
+  # skipped tests are marked as succesfull in GitHub required test, we test here
+  # if it was succesfully run and then mark it as such, if it's skipped or fails
+  # then it's marked as failed.
+  completed:
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    needs: [terraform-file-changes, tf-apply]
+    outputs:
+      tf-apply-result: ${{ needs.tf-apply.result }}
+    steps:
+      - name: No Terraform changes, or Terraform applied successfully
+        id: workflow-or-terraform-change
+        if: ${{ (needs.terraform-file-changes.outputs.result == 'false')  || (needs.tf-apply.result  == 'success') }}
+        run: exit 0
+      - name: Non-terraform change, or terraform apply failed
+        if: failure() || steps.workflow-or-terraform-change.outcome != 'success'
+        run: exit 1
+
+  merge-into-master:
+    if: ${{ always() && (needs.tf-apply.result == 'success' || needs.tf-apply.result == 'skipped') }}
+    needs: [tf-apply, completed]
+    uses: guidion-digital/release-workflows/.github/workflows/github-merge-into-master.yaml@v2
+    with:
+      branch: ${{ github.ref_name }}
+    permissions:
+      contents: write
+
+  release-tag:
+    if: ${{ needs.tf-apply.result == 'success' && needs.merge-into-master.result == 'success' }}
+    needs: [tf-apply, merge-into-master]
+    uses: guidion-digital/release-workflows/.github/workflows/github-release-tag.yaml@v2
+    with:
+      branch: ${{ github.ref_name }}
+    permissions:
+      contents: write

--- a/.github/workflows/tfc-test-helper-module-apply.yaml
+++ b/.github/workflows/tfc-test-helper-module-apply.yaml
@@ -52,6 +52,9 @@ jobs:
         uses: LocalStack/setup-localstack@main
         with:
           image-tag: 'latest'
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.6.4"
       - name: Install tflocal
         run: pip install terraform-local
       - name: Test API

--- a/.github/workflows/tfc-test-helper-module-plan.yaml
+++ b/.github/workflows/tfc-test-helper-module-plan.yaml
@@ -44,6 +44,9 @@ jobs:
         uses: LocalStack/setup-localstack@main
         with:
           image-tag: 'latest'
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.6.4"
       - name: Install tflocal
         run: pip install terraform-local
       - name: Test API


### PR DESCRIPTION
This workflow can be used for applying without a TFC workspace.

Tested [here](https://github.com/guidion-digital/terraform-aws-helper-secrets/blob/CI-630/.github/workflows/test-apply-and-release.yaml), and [here's the run](https://github.com/guidion-digital/terraform-aws-helper-secrets/actions/runs/19335926272)